### PR TITLE
Dev

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,7 +19,7 @@
       "name": "Glyphe"
     }
   ],
-  "version": "0.9.42",
+  "version": "0.9.44",
   "compatibility": {
     "minimum": "10",
     "verified": "10.291"
@@ -32,7 +32,7 @@
         "manifest": "https://raw.githubusercontent.com/EndlesNights/dnd4eBeta/main/system.json",
         "compatibility": {
           "minimum": "0.3.17",
-          "verified": "0.3.20"
+          "verified": "0.3.24"
         }
       }
     ]
@@ -46,7 +46,8 @@
     "styles/sheets.css"
   ],
   "scripts": [
-    "scripts/helpers.js"
+    "scripts/helpers.js",
+    "scripts/chat.js"
   ],
   "esmodules": [
     "4e-styling.js",

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -1,0 +1,4 @@
+Hooks.on("renderChatMessage", (app, html, data) => {
+	// Collapse NPC power cards by default (because they almost never have flavour entries)
+	html.find(".power-card.NPC .card-content").hide();
+});

--- a/styles/sheets.css
+++ b/styles/sheets.css
@@ -65,7 +65,6 @@
 .sheet.fox4e .sheet-body input[type='checkbox']{
 	height:0.8rem;
 	vertical-align:middle;
-	margin-top:-0.55em;
 }
 .sheet.fox4e .sheet-body h1,
 .sheet.fox4e .sheet-body h2,
@@ -306,6 +305,9 @@
 	line-height:1.25em;
 	font-variant:small-caps;
 }
+.sheet.fox4e.npc .sheet-body input[type='checkbox']{
+	margin-top:-0.55em;
+}
 
 
 /*---------- All Sections — Owned Item Lists ----------*/
@@ -418,19 +420,11 @@
 	padding:1px 12px 4px 6px;
 	overflow:hidden;
 }
-.sheet.fox4e.npc .sheet-body .head ::-webkit-input-placeholder{
-	color:rgba(255,255,255,0.3);
-}
-.sheet.fox4e.npc .sheet-body .head ::-moz-placeholder{
-	color:rgba(255,255,255,0.3);
-}
-.sheet.fox4e.npc .sheet-body .head :-ms-input-placeholder{
-	color:rgba(255,255,255,0.3);
-}
-.sheet.fox4e.npc .sheet-body .head ::-ms-input-placeholder{
-	color:rgba(255,255,255,0.3);
-}
-.sheet.fox4e.npc .sheet-body .head ::placeholder{
+.sheet.fox4e.npc .sheet-body .head ::-webkit-input-placeholder,
+.sheet.fox4e.npc .sheet-body .head ::-moz-placeholder,
+.sheet.fox4e.npc .sheet-body .head :-ms-input-placeholder,
+.sheet.fox4e.npc .sheet-body .head ::-ms-input-placeholder,
+sheet.fox4e.npc .sheet-body .head ::placeholder{
 	color:rgba(255,255,255,0.3);
 }
 .sheet.fox4e.npc .sheet-body .head>.flexcol>.flexrow{
@@ -562,6 +556,9 @@
 .sheet.fox4e.npc .sheet-body .hp .temp input[value="0"]+.ruler,
 .sheet.fox4e.npc .sheet-body .action-points input[value="0"]+.ruler{
 	color:rgba(0,0,0,0.3);
+}
+.sheet.fox4e.npc .sheet-body .dmg-taken-mods:not(.dmg-res,.dmg-vuln,.dmg-imm,.spec-imm,.spec-res,.spec-vuln){
+	display:none;
 }
 .sheet.fox4e.npc .sheet-body .dmg-taken-mods>div{
 	display:inline-block;
@@ -899,6 +896,13 @@
 .sheet.fox4e.npc .sheet-body .res-special-body>p:first-child{
 	margin-top:0;
 }
+.sheet.fox4e.npc .sheet-body .res-special-body .traits-list,
+.sheet.fox4e.npc .sheet-body .res-special-body .traits-list>*:not(.hidden){
+	display:inline;
+}
+.sheet.fox4e.npc .sheet-body .res-special-body .traits-list>li:not(:last-child)::after{
+	content:', ';
+}
 
 
 /*---------- Effects Tab ----------*/
@@ -985,4 +989,263 @@
 	border:0;
    margin-bottom:-2px;
 	margin-right:2px;
+}
+
+
+
+/***************************************************/
+/*         PC SHEETS                               */
+/***************************************************/
+
+/*---------- All Sections ----------*/
+
+.sheet.fox4e.pc .window-content{
+	background:#fff;
+	padding:0;
+	overflow:hidden;
+	/*-background:url('../images/char-sheet-bg.webp') no-repeat;
+	background-size:cover;-*/
+}
+.sheet.fox4e.pc .sheet-body .autosize .ruler{
+	color:#fff;
+}
+.sheet.fox4e.pc .sheet-body label.hiding:not(.visible,.required) .display{
+	display:none;
+}
+.sheet.fox4e.pc .sheet-body h2,
+.sheet.fox4e.pc .sheet-body h3,
+.sheet.fox4e.pc .sheet-body h4,
+.sheet.fox4e.pc .sheet-body h5,
+.sheet.fox4e.pc .sheet-body h6{
+	color:#193d5e;
+	font-family:'DragonHead';
+}
+.sheet.fox4e.pc .sheet-body h2{
+	font-size:0.9em;
+	text-transform:uppercase;
+	font-weight:800;
+}
+.sheet.fox4e.pc .sheet-body .button{
+	display:inline-block;
+	white-space:nowrap;
+	margin-top:1px;
+	margin-bottom:1px;
+	padding:0.1rem 0.4rem;
+	background:transparent;
+	border-radius:4px;
+	border-top:1px solid #fff;
+	border-bottom:1px solid #d4bf95;
+	border-right:1px solid #d4bf95;
+	text-transform:uppercase;
+	font-size:0.65rem;
+	text-align:center;
+}
+.sheet.fox4e.pc .sheet-body .label{
+	font-size:0.68rem;
+	text-transform:uppercase;
+	font-weight:400;
+	line-height:1;
+	display:inline-block;
+}
+
+/*---------- Header Banner ----------*/
+
+.sheet.fox4e.pc .sheet-body .char-title ::-webkit-input-placeholder,
+.sheet.fox4e.pc .sheet-body .char-title ::-moz-placeholder,
+.sheet.fox4e.pc .sheet-body .char-title :-ms-input-placeholder,
+.sheet.fox4e.pc .sheet-body .char-title ::-ms-input-placeholder,
+sheet.fox4e.pc .sheet-body .char-title ::placeholder{
+	color:rgba(255,255,255,0.3);
+}
+.sheet.fox4e.pc .sheet-body .char-title{
+	position:relative;
+	top:1.3em;
+	background:#193d5e;
+	color:#fff;
+	padding:0.5em 0.8em 0.8em 0.5em;
+	border:2px solid #c2ae41;
+	border-left:none;
+	display:flex;
+	align-items:center;
+	margin-right:1em;
+	border-radius:0 20px 0 0;
+	margin-bottom:1.3em;
+}
+.sheet.fox4e.pc .sheet-body .char-title img.portrait{
+	border:2px solid #c2ae41;
+	margin-bottom:-50px;
+	margin-top:-50px;
+	border-radius:100px;
+	width:100px;
+	height:100px;
+	z-index:1;
+}
+.sheet.fox4e.pc .sheet-body .char-title img.portrait::before{
+	content:'BIGFART';
+	background:url('../images/portrait-frame.png');
+	display:block;
+	position:relative;
+}
+.sheet.fox4e.pc .sheet-body .char-title .banner-text{
+	margin-left:0.5em;
+}
+.sheet.fox4e.pc .sheet-body .char-title .autosize.empty input,
+.sheet.fox4e.pc .sheet-body .char-title .autosize:not(.visible) .ruler{
+	color:rgba(255,255,255,0.3);
+}
+.sheet.fox4e.pc .sheet-body .char-title .autosize.name,
+.sheet.fox4e.pc .sheet-body .char-title .autosize>input.name{
+	font-family:'DragonHead';
+	font-variant:small-caps;
+}
+.sheet.fox4e.pc .sheet-body .char-title .autosize>input.name{
+	font-size:2em;
+}
+.sheet.fox4e.pc .sheet-body .char-title .summary-exp{
+	position:absolute;
+	top:0;
+	right:0;
+	padding:0.5rem 0.8rem;
+}
+.sheet.fox4e.pc .sheet-body .char-title .summary-level{
+	position:absolute;
+	bottom:0;
+	right:0;
+	padding:0.5rem 0.8rem;
+	font-size:1.2em;
+}
+.sheet.fox4e.pc .sheet-body .char-title:focus-within label.hiding:not(.visible) .display{
+	display:inline-block;
+}
+.sheet.fox4e.pc .sheet-body .char-title label.hiding:not(.visible) .display{
+	color:rgba(255,255,255,0.3);
+}
+.sheet.fox4e.pc .sheet-body .char-title label.paragon.visible::before,
+.sheet.fox4e.pc .sheet-body .char-title label.epic.visible::before,
+.sheet.fox4e.pc .sheet-body .char-title label.paragon.required::before,
+.sheet.fox4e.pc .sheet-body .char-title label.epic.required::before{
+	content:'\2009\2009/';
+}
+.sheet.fox4e.pc .sheet-body .char-title:focus-within label.paragon::before,
+.sheet.fox4e.pc .sheet-body .char-title:focus-within label.epic::before{
+	content:'\2009/\2009';
+}
+
+
+/*---------- Header Vitals ----------*/
+
+.sheet.fox4e.pc .sheet-body .vitals{
+	position:relative;
+	top:0.5em;
+	margin:0.5em;
+	background:-webkit-gradient(linear, right top, left top, from(rgba(255,255,255,1)), to(rgba(221,220,203,1)));
+	background:-o-linear-gradient(right, rgba(255,255,255,1) 0%, rgba(221,220,203,1) 50%);
+	background:linear-gradient(270deg, rgba(255,255,255,1) 0%, rgba(221,220,203,1) 50%);
+	padding:0.5em 1em;
+	justify-content:space-between;
+}
+.sheet.fox4e.pc .sheet-body .vitals>hr{
+	border-right:1px dotted #fff;
+	width:1px;
+}
+.sheet.fox4e.pc .sheet-body .vitals h2{
+	text-align:center;
+	margin-bottom:0.3em;
+}
+.sheet.fox4e.pc .sheet-body .vitals input[type="text"].number{
+	width:2.1rem;
+	text-align:right;
+	margin-top:1px;
+	margin-bottom:1px;
+	box-shadow:inset 0 -1px rgba(0,0,0,0.1);
+}
+.sheet.fox4e.pc .sheet-body .vitals .attribute-box{
+	align-items:center;
+	background:transparent top center no-repeat;
+	background-size:contain;
+	width:26px;
+	padding-top:1px;
+	flex-direction:column-reverse;
+}
+.sheet.fox4e.pc .sheet-body .vitals .temp-hp{
+	text-align:right;
+}
+.sheet.fox4e.pc .sheet-body .vitals .flexrow.surges{
+	align-items:center;
+}
+.sheet.fox4e.pc .sheet-body .vitals .label.left{
+	text-align:right;
+	width:44px;
+	margin-right:4px;
+}
+.sheet.fox4e.pc .sheet-body .vitals .rest.flexrow{
+	justify-content:stretch;
+}
+.sheet.fox4e.pc .sheet-body .vitals .rest.flexrow>*{
+	flex-basis:50%;
+}
+.sheet.fox4e.pc .sheet-body .vitals .attribute-defenses .attribute-box{
+	background-image:url('../images/box_defence.svg');
+}
+.sheet.fox4e.pc .sheet-body .vitals .attribute-defenses .attribute-box:not(:first-child){
+	margin-left:0.5em;
+}
+.sheet.fox4e.pc .sheet-body .vitals .section--saves{
+	align-items:center;
+	margin-top:1em;
+}
+.sheet.fox4e.pc .sheet-body .vitals .section--saves img{
+	border:none;
+}
+.sheet.fox4e.pc .sheet-body .vitals .tracking-surges.attribute-box{
+	flex-direction:row-reverse;
+	width:auto;
+}
+.sheet.fox4e.pc .sheet-body .vitals .tracking-surges.attribute-box>.attribute-value{
+	background:url('../images/box_hp.svg') center center no-repeat;
+	background-size:contain;
+	padding:6px;
+	display:inline-block;
+}
+.sheet.fox4e.pc .sheet-body .vitals .tracking-surges .label{
+	max-width:45px;
+}
+.sheet.fox4e.pc .sheet-body .vitals .tracking-2w.attribute-box{
+	flex-direction:row-reverse;
+	align-items:center;
+}
+.sheet.fox4e.pc .sheet-body .vitals .rest .button{
+	flex-basis:unset;
+	padding:0;
+	height:auto;
+	width:auto;
+	line-height:0;
+}
+.sheet.fox4e.pc .sheet-body .vitals .rest .button .button-icon{
+	height:0.95rem;
+	width:1.1rem;
+	border:none;
+	margin:0.1rem;
+	object-fit:contain;
+}
+.sheet.fox4e.pc .sheet-body .vitals .rest .button .label{
+	display:none;
+}
+.sheet.fox4e.pc .sheet-body .vitals .rest.flexrow{
+	justify-content:space-between;
+}
+.sheet.fox4e.pc .sheet-body .vitals .health-sidebar{
+	margin-left:1em;
+}
+.sheet.fox4e.pc .sheet-body .vitals .speed.attribute-box>.attribute-value{
+	background:url('../images/box_speed.svg') center center no-repeat;
+	background-size:contain;
+	padding:6px;
+	display:inline-block;
+}
+.sheet.fox4e.pc .sheet-body .vitals .initiative.attribute-box>.attribute-value{
+	background:url('../images/box_initiative.svg') center center no-repeat;
+	background-size:contain;
+	padding:6px;
+	display:inline-block;
 }

--- a/templates/npc-sheet.html
+++ b/templates/npc-sheet.html
@@ -228,11 +228,35 @@
 					<span class="tag {{k}}">{{v}}</span>
 				{{/each}}
 			</div>
+
+			<div class="dmg-taken-mods	{{!-- 
+			Ugly mess to avoid space being given to empty line 
 			
-			<div class="dmg-taken-mods" title="{{localize 'Fox4e.TipResistances'}}&mdash;{{localize 'Fox4e.TipEditOnManage'}}">{{!--
+			--}}{{#if (laden system.untypedResistances.immunities)}}{{!--
+				--}} spec-imm{{!--
+			--}}{{else if (laden system.untypedResistances.resistances)}}{{!--
+				--}} spec-res{{!--
+			--}}{{else if (laden system.untypedResistances.vulnerabilities)}}{{!--
+				--}} spec-vuln{{!--
+			--}}{{/if}}{{!--
+			
+			--}}{{#each system.resistances as |res r|}}{{!--
+				--}}{{#if (gt res.value 0)}}{{#unless res.immune}}{{!--
+					--}} dmg-res{{!--
+				--}}{{/unless}}{{/if}}{{!--
+				--}}{{#if (lt res.value 0)}}{{#unless res.immune}}{{!--
+					--}} dmg-vuln{{!--
+				--}}{{/unless}}{{/if}}{{!--
+				--}}{{#if res.immune}}{{!--
+					--}} dmg-imm{{!--
+				--}}{{/if}}{{!--
+			--}}{{/each}}{{!--
+			
+			{{!-- End ugly mess 	
+			--}}" title="{{localize 'Fox4e.TipResistances'}}&mdash;{{localize 'Fox4e.TipEditOnManage'}}">{{!--
 			
 				--}}<div class="immunities">{{!--
-					--}}<span class="label">{{localize 'Fox4e.DamImmune'}} </span>{{!--
+					--}}<span class="label">{{localize 'Fox4e.Immune'}} </span>{{!--
 
 					--}}{{#if (laden system.untypedResistances.immunities)}}{{!--
 						--}}{{#each system.untypedResistances.immunities as |imm|}}{{!--
@@ -255,7 +279,7 @@
 				--}}</div>{{!-- [Close] Immunities section --}}{{!--
 					
 				--}}<div class="resistances">{{!--
-					--}}<span class="label">{{localize 'Fox4e.DamResist'}} </span>{{!--
+					--}}<span class="label">{{localize 'Fox4e.Resist'}} </span>{{!--
 					
 					--}}{{#each system.resistances as |res r|}}{{!--
 						--}}{{#if (gt res.value 0)}}{{#unless res.immune}}{{!--
@@ -281,7 +305,7 @@
 				--}}</div>{{!-- [Close] Resistances section--}}{{!--
 					
 				--}}<div class="vulnerabilities">{{!--
-					--}}<span class="label">{{localize 'Fox4e.DamVulnerable'}} </span>{{!--
+					--}}<span class="label">{{localize 'Fox4e.Vulnerable'}} </span>{{!--
 					
 					--}}{{#each system.resistances as |res r|}}{{!--
 						--}}{{#if (lt res.value 0)}}{{!--
@@ -721,7 +745,7 @@
 								<th class="res-name">{{localize 'DND4EBETA.Type'}}</th>
 								{{#if system.advancedCals}}<th class="res-value">{{localize 'Fox4e.Total'}}</th>{{/if}}
 								<th class="res-bonus">{{#if system.advancedCals}}{{localize 'Fox4e.Base'}}{{else}}{{localize 'DND4EBETA.Value'}}{{/if}}</th>
-								<th class="res-imm">{{localize 'Fox4e.DamImmune'}}</th>
+								<th class="res-imm">{{localize 'Fox4e.Immune'}}</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -739,8 +763,42 @@
 					
 					<div class="res-special">
 						<h3 class="subsection">{{localize 'Fox4e.TabResistancesExtra'}}</h3>
-						<div class="res-special-body">
-							<p>Condition & special resistances will be editable here in a future version.</p>
+						<div class="res-special-body">	
+							<div>
+								<a class="list-string-input label untyped-resistances" data-options="special" data-target="system.untypedResistances.resistances" title="{{ localize 'Fox4e.TipEdit' }} {{ localize 'DND4EBETA.UntypedRes'}}">
+									<span>{{ localize "Fox4e.Resist" }}</span>
+									<i class="fas fa-edit"></i>
+								</a>							
+								<ul class="traits-list">
+								{{#each system.untypedResistances.resistances as |v k|}}
+									<li class="tag {{k}}">{{v}}</li>
+								{{/each}}
+								</ul>
+							</div>
+							
+							<div>
+								<a class="list-string-input label untyped-vulnerabilities" data-options="special" data-target="system.untypedResistances.vulnerabilities" title="{{ localize 'Fox4e.TipEdit' }} {{ localize 'DND4EBETA.UntypedVuln'}}">
+									<span>{{ localize "Fox4e.Vulnerable" }}</span>
+									<i class="fas fa-edit"></i>
+								</a>								
+								<ul class="traits-list">
+								{{#each system.untypedResistances.vulnerabilities as |v k|}}
+									<li class="tag {{k}}">{{v}}</li>
+								{{/each}}
+								</ul>
+							</div>
+							
+							<div>
+								<a class="list-string-input label untyped-immunities" data-options="special" data-target="system.untypedResistances.immunities" title="{{ localize 'Fox4e.TipEdit' }} {{ localize 'DND4EBETA.UntypedImm'}}">
+									<span>{{ localize "Fox4e.Immune" }}</span>
+									<i class="fas fa-edit"></i>
+								</a>							
+								<ul class="traits-list">
+								{{#each system.untypedResistances.immunities as |v k|}}
+									<li class="tag {{k}}">{{v}}</li>
+								{{/each}}
+								</ul>
+							</div>
 						</div>
 						
 					</div>


### PR DESCRIPTION
-  Added the chat.js scripts file to handle auto-collapse of NPC chat card flavour.
-  Resistances area on the NPC sheet no longer takes up space while empty. This should make simple monsters a bit more compact.
-  Since my "don't output flavour for auto-generated NPC chat cards" logic was reverted in the system module, I've replaced it with a simple bit of logic to collapse the flavour area on NPC chat cards by default.
-  Added classes to the containing div for the Resistances area, so we can tell when it's empty, and what type of content it has when full. (Used primarily for hiding the area when empty.)
   - ATM this outputs the class once for every instance it finds in the resistances array, which is less than ideal, but does work. Maybe at some stage I'll come up with an elegant way to avoid it, but the only ways I can think of right now would massively overcomplicate the template code, so I don't wanna.